### PR TITLE
Add interval-based rotation and script hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,9 @@ This project attempts to implement Windows service similiar to unix logrotate as
 
 ### Features
 - Delete or rotate logs (or any files really)
-- Option to delete/rotate conditionally based on file age or size
+- Option to delete/rotate conditionally based on file age, size, or time interval
 - Compression for rotated files in gzip/zip
-- TODO delete/rotate on time interval condition
-- TODO pre/post custom script
+- Support for pre/post custom scripts
 
 ### Configuration
 See configs/wingologrotate.yaml for example config.

--- a/config.go
+++ b/config.go
@@ -11,9 +11,11 @@ import (
 type Paths []string
 
 type LogEntry struct {
-	Path      Paths      `yaml:"path"`
-	Type      string     `yaml:"type"`
-	Condition *Condition `yaml:"condition,omitempty"`
+	Path       Paths      `yaml:"path"`
+	Type       string     `yaml:"type"`
+	Condition  *Condition `yaml:"condition,omitempty"`
+	PreScript  *string    `yaml:"pre_script,omitempty"`
+	PostScript *string    `yaml:"post_script,omitempty"`
 }
 
 type Condition struct {
@@ -31,20 +33,20 @@ type Config struct {
 }
 
 func (entry *LogEntry) setDefaults() {
-    if entry.Type != "rotate" {
-        return
-    }
-    if entry.Condition == nil {
-        entry.Condition = &Condition{}
-    }
-    if entry.Condition.Compress == nil {
-        defaultCompress := true
-        entry.Condition.Compress = &defaultCompress
-    }
-    if entry.Condition.CompressionFormat == nil {
-        defaultFormat := "gzip"
-        entry.Condition.CompressionFormat = &defaultFormat
-    }
+	if entry.Type != "rotate" {
+		return
+	}
+	if entry.Condition == nil {
+		entry.Condition = &Condition{}
+	}
+	if entry.Condition.Compress == nil {
+		defaultCompress := true
+		entry.Condition.Compress = &defaultCompress
+	}
+	if entry.Condition.CompressionFormat == nil {
+		defaultFormat := "gzip"
+		entry.Condition.CompressionFormat = &defaultFormat
+	}
 }
 
 func loadConfig(filePath string) (Config, error) {

--- a/config_test.go
+++ b/config_test.go
@@ -11,6 +11,10 @@ func TestLoadConfig(t *testing.T) {
 logs:
   - path: "/path/to/log/*.log"
     type: delete
+    pre_script: "echo pre"
+    post_script: "echo post"
+    condition:
+      time_interval: "1h"
   - path:
       - "/path/to/log1/*.log"
       - "/path/to/log2/*.log"
@@ -36,6 +40,15 @@ schedule: "*/5 * * * *"
 
 	if config.Logs[0].Type != "delete" {
 		t.Errorf("Expected type 'delete', got %s", config.Logs[0].Type)
+	}
+	if config.Logs[0].PreScript == nil || *config.Logs[0].PreScript != "echo pre" {
+		t.Errorf("Expected pre_script 'echo pre', got %v", config.Logs[0].PreScript)
+	}
+	if config.Logs[0].PostScript == nil || *config.Logs[0].PostScript != "echo post" {
+		t.Errorf("Expected post_script 'echo post', got %v", config.Logs[0].PostScript)
+	}
+	if config.Logs[0].Condition == nil || config.Logs[0].Condition.TimeInterval == nil || *config.Logs[0].Condition.TimeInterval != "1h" {
+		t.Errorf("Expected time_interval '1h', got %v", config.Logs[0].Condition)
 	}
 
 	if len(config.Logs[1].Path) != 2 {

--- a/logrotate.go
+++ b/logrotate.go
@@ -46,7 +46,28 @@ func runLogRotation() {
 }
 
 func createTask(logEntry LogEntry) func() {
+	var lastRun time.Time
 	return func() {
+		now := time.Now()
+		if logEntry.Condition != nil && logEntry.Condition.TimeInterval != nil {
+			interval, err := parseDuration(*logEntry.Condition.TimeInterval)
+			if err != nil {
+				log.Printf("Invalid time interval for paths %v: %v", logEntry.Path, err)
+				return
+			}
+			if !lastRun.IsZero() && now.Sub(lastRun) < interval {
+				log.Printf("Skipping task for paths %v; next run in %v", logEntry.Path, interval-now.Sub(lastRun))
+				return
+			}
+			lastRun = now
+		}
+
+		if logEntry.PreScript != nil {
+			if err := runScript(*logEntry.PreScript); err != nil {
+				log.Printf("Pre-script failed for paths %v: %v", logEntry.Path, err)
+			}
+		}
+
 		for _, path := range logEntry.Path {
 			log.Printf("Running task for path: %s", path)
 			matchingFiles, err := filepath.Glob(filepath.Clean(path))
@@ -91,6 +112,12 @@ func createTask(logEntry LogEntry) func() {
 
 			default:
 				log.Printf("Unsupported task type: %s", logEntry.Type)
+			}
+		}
+
+		if logEntry.PostScript != nil {
+			if err := runScript(*logEntry.PostScript); err != nil {
+				log.Printf("Post-script failed for paths %v: %v", logEntry.Path, err)
 			}
 		}
 	}
@@ -147,18 +174,18 @@ func rotateLogFiles(logEntry LogEntry) {
 				}
 				log.Printf("Rotated log file: %s to %s", file, rotatedFilePath)
 
-                if logEntry.Condition.Compress == nil || *logEntry.Condition.Compress {
-                    // Use configured compression format if provided, default to gzip
-                    format := "gzip"
-                    if logEntry.Condition != nil && logEntry.Condition.CompressionFormat != nil {
-                        format = *logEntry.Condition.CompressionFormat
-                    }
-                    if err := compressLogFile(rotatedFilePath, format); err != nil {
-                        log.Printf("Failed to compress rotated log file %s: %v", rotatedFilePath, err)
-                    } else {
-                        log.Printf("Compressed log file: %s", rotatedFilePath)
-                    }
-                }
+				if logEntry.Condition.Compress == nil || *logEntry.Condition.Compress {
+					// Use configured compression format if provided, default to gzip
+					format := "gzip"
+					if logEntry.Condition != nil && logEntry.Condition.CompressionFormat != nil {
+						format = *logEntry.Condition.CompressionFormat
+					}
+					if err := compressLogFile(rotatedFilePath, format); err != nil {
+						log.Printf("Failed to compress rotated log file %s: %v", rotatedFilePath, err)
+					} else {
+						log.Printf("Compressed log file: %s", rotatedFilePath)
+					}
+				}
 
 				if logEntry.Condition.MaxKeep != nil {
 					if err := removeOldLogFiles(filepath.Dir(file), filepath.Base(file), *logEntry.Condition.MaxKeep); err != nil {

--- a/logrotate_test.go
+++ b/logrotate_test.go
@@ -3,12 +3,14 @@ package main
 import (
 	"bytes"
 	"compress/gzip"
+	"fmt"
 	"io"
 	"log"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestRotateLogFiles(t *testing.T) {
@@ -94,5 +96,58 @@ func TestCreateTask(t *testing.T) {
 
 	if !strings.Contains(logBuf.String(), "Running task for path: /tmp/test/logs/delete/*.log") {
 		t.Errorf("Expected log output for running task, got %s", logBuf.String())
+	}
+}
+
+func TestPrePostScripts(t *testing.T) {
+	tempDir := t.TempDir()
+	targetFile := filepath.Join(tempDir, "test.log")
+	if err := os.WriteFile(targetFile, []byte("data"), 0644); err != nil {
+		t.Fatalf("Failed to create log file: %v", err)
+	}
+	preFile := filepath.Join(tempDir, "pre.txt")
+	postFile := filepath.Join(tempDir, "post.txt")
+
+	logEntry := LogEntry{
+		Path:       Paths{targetFile},
+		Type:       "delete",
+		PreScript:  stringPtr(fmt.Sprintf("echo pre > %s", preFile)),
+		PostScript: stringPtr(fmt.Sprintf("echo post > %s", postFile)),
+	}
+
+	task := createTask(logEntry)
+	task()
+
+	if _, err := os.Stat(preFile); err != nil {
+		t.Errorf("pre script did not execute: %v", err)
+	}
+	if _, err := os.Stat(postFile); err != nil {
+		t.Errorf("post script did not execute: %v", err)
+	}
+}
+
+func TestTimeIntervalCondition(t *testing.T) {
+	tempDir := t.TempDir()
+	marker := filepath.Join(tempDir, "marker.txt")
+	logEntry := LogEntry{
+		Path:      Paths{filepath.Join(tempDir, "*.log")},
+		Type:      "delete",
+		PreScript: stringPtr(fmt.Sprintf("echo run >> %s", marker)),
+		Condition: &Condition{TimeInterval: stringPtr("1s")},
+	}
+
+	task := createTask(logEntry)
+	task()
+	task()
+	time.Sleep(1 * time.Second)
+	task()
+
+	data, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatalf("failed to read marker: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected script to run twice, ran %d times", len(lines))
 	}
 }

--- a/utils.go
+++ b/utils.go
@@ -7,7 +7,9 @@ import (
 	"io"
 	"log"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -44,6 +46,18 @@ func closeLogFile() {
 			log.Printf("Error closing log file: %v", err)
 		}
 	}
+}
+
+func runScript(script string) error {
+	var cmd *exec.Cmd
+	if runtime.GOOS == "windows" {
+		cmd = exec.Command("cmd", "/C", script)
+	} else {
+		cmd = exec.Command("sh", "-c", script)
+	}
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	return cmd.Run()
 }
 
 func parseDuration(ageStr string) (time.Duration, error) {


### PR DESCRIPTION
## Summary
- allow log entries to specify time-based intervals for execution
- add pre/post script hooks for custom actions
- support running custom scripts and parsing new config fields

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68aa2e9c70408324978c3bfa05f08d9c